### PR TITLE
Fix hangouts handler method signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+vendor
+composer.lock
+.phpunit.result.cache
+.idea
+.vscode

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/monolog-hangouts-handler.iml" filepath="$PROJECT_DIR$/.idea/monolog-hangouts-handler.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/monolog-hangouts-handler.iml
+++ b/.idea/monolog-hangouts-handler.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
   "description": "A simple monolog handler for Google Hangouts Chat webhooks",
   "type": "library",
   "require": {
-    "monolog/monolog":"*",
-    "guzzlehttp/guzzle":"*"
+    "monolog/monolog": "*",
+    "guzzlehttp/guzzle": "*"
   },
   "license": "MIT",
   "authors": [
@@ -17,5 +17,9 @@
     "psr-4": {
       "Nowyn\\Monolog\\": "src"
     }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "*",
+    "mockery/mockery": "*"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory suffix="Test.php">src</directory>
+        </exclude>
+    </coverage>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">test</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/HangoutsChatHandler.php
+++ b/src/HangoutsChatHandler.php
@@ -5,6 +5,7 @@ namespace Nowyn\Monolog;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use GuzzleHttp\Client;
+use Monolog\Formatter\FormatterInterface;
 
 class HangoutsChatHandler extends AbstractProcessingHandler
 {
@@ -34,7 +35,7 @@ class HangoutsChatHandler extends AbstractProcessingHandler
     /**
      * @return \Monolog\Formatter\FormatterInterface|HangoutsChatFormatter
      */
-    public function getFormatter()
+    public function getFormatter(): FormatterInterface
     {
         return new HangoutsChatFormatter();
     }
@@ -44,14 +45,15 @@ class HangoutsChatHandler extends AbstractProcessingHandler
      *
      * @throws \RuntimeException
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $message = $this->getFormatter()
-                        ->format($record);
-        $this->client->post($this->webhookUrl, ['headers' => ['Content-Type' => 'application/json'],
-                                                'body' => $message,
-                                                'curl' => [CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2],
-                                                'http_errors' => false]);
+            ->format($record);
+        $this->client->post($this->webhookUrl, [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => $message,
+            'curl' => [CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2],
+            'http_errors' => false
+        ]);
     }
-
 }

--- a/test/HangoutsHandlerTest.php
+++ b/test/HangoutsHandlerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\Log;
+
+use Mockery;
+use Mockery\MockInterface;
+use Monolog\Logger;
+use Nowyn\Monolog\HangoutsChatHandler;
+use PHPUnit\Framework\TestCase;
+
+class HangoutsLogHandlerTest extends TestCase
+{
+
+    public function testCanSendLogMessagesToHangouts()
+    {
+        $logger = new Logger('test');
+
+
+        /** @var MockInterface|HangoutsChatHandler $hangoutsDriver */
+        $hangoutsDriver = Mockery::mock(
+            HangoutsChatHandler::class . '[write]',
+            ['https://test.example.com', null, Logger::INFO]
+        )->shouldAllowMockingProtectedMethods();
+
+        $hangoutsDriver->shouldReceive('write')->once();
+
+        $logger->pushHandler($hangoutsDriver);
+
+        $logger->critical('test message');
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
There is a method signature missmatch error when running the handler on the latest monolog version (used in Laravel 8). This PR fixes it and adds a test.